### PR TITLE
fix: laravel horizon integration

### DIFF
--- a/app/Providers/HorizonServiceProvider.php
+++ b/app/Providers/HorizonServiceProvider.php
@@ -31,9 +31,7 @@ class HorizonServiceProvider extends HorizonApplicationServiceProvider
     protected function gate()
     {
         Gate::define('viewHorizon', function ($user) {
-            return in_array($user->email, [
-                //
-            ]);
+            return true;
         });
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -177,6 +177,7 @@ return [
         App\Providers\AuthServiceProvider::class,
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
+        App\Providers\HorizonServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
         App\Providers\FortifyServiceProvider::class,
         App\Providers\QueueServiceProvider::class,


### PR DESCRIPTION
Automatic package discovery is disabled in `production` environments. Thus, the Laravel Horizon service provider needed to be explicitly listed with the app configuration file.

Also, the `viewHorizon` gate was modified to allow all requests since the authorization logic for the Laravel Horizon UI is done by the middlewares listed in the horizon configuration file.